### PR TITLE
Add TestFlight mod's interface to exception

### DIFF
--- a/ModsExceptions.txt
+++ b/ModsExceptions.txt
@@ -69,6 +69,10 @@ Screenshots
 //StageRecovery
 StageRecovery -nm -nr -nn
 //
+//TestFlight interface elements will cause DDS4KSP to crash
+TestFlight\Resources -nn -nm -nr
+TestFlight\Resources\Textures -nn -nm -nr
+//
 //TextureReplacer's helmet visor, this prog still can't get the p8 format, but nvdxt or crunch could probably do it.
 TextureReplacer\EnvMap
 //


### PR DESCRIPTION
I would like my mod's interface elements to be added to the exception list please.  For some reason they case DDS4KSP to crash when it encounters them.  This fixes it.
